### PR TITLE
added rpcURL and sepolia mappings

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export const ASSETS: { [key: string]: Asset } = {
   [ChainId.KOVAN]: { assetId: 'ETH_TEST2', rpcUrl: "https://kovan.poa.network" },
   [ChainId.GOERLI]: { assetId: 'ETH_TEST3', rpcUrl: "https://rpc.ankr.com/eth_goerli" },
   [ChainId.RINKEBY]: { assetId: 'ETH_TEST4', rpcUrl: "https://rpc.ankr.com/eth_rinkeby" },
+  [ChainId.SEPOLIA]: { assetId: 'ETH_TEST5', rpcUrl: "https://rpc.sepolia.org" },
   [ChainId.BSC]: { assetId: 'BNB_BSC', rpcUrl: "https://bsc-dataseed.binance.org" },
   [ChainId.BSC_TEST]: { assetId: 'BNB_TEST', rpcUrl: "https://data-seed-prebsc-1-s1.binance.org:8545" },
   [ChainId.POLYGON]: { assetId: 'MATIC_POLYGON', rpcUrl: "https://polygon-rpc.com" },

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export enum ChainId {
   KOVAN = 42,
   GOERLI = 5,
   RINKEBY = 4,
+  SEPOLIA = 11155111,
   BSC = 56,
   BSC_TEST = 97,
   POLYGON = 137,


### PR DESCRIPTION
Ran into issues deploying to Sepolia Testnet (ChainID not supported) using the @fireblocks/hardhat-fireblocks plugin, I tracked down the issue to the mappings not being set up on @fireblocks/fireblocks-web3-provider.

Simple fix here. 

