### PR TITLE
Fix tenderly simulation URL params

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -380,7 +380,7 @@ export class FireblocksWeb3Provider extends HttpProvider {
     })));
 
     if (!searchParams.get('gasPrice') && tx.maxFeePerGas) {
-      searchParams.set('gasPrice', tx.maxFeePerGas)
+      searchParams.set('gasPrice', String(Number(tx.maxFeePerGas)))
     }
 
     return `https://dashboard.tenderly.co/simulator/new?${searchParams.toString()}`


### PR DESCRIPTION
Fix tenderly simulation URL search params with converting the hex value to a number in case of "maxFeePerGas" value in the tx object.