### PR TITLE
fix : remove unavailable testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,48 +3,56 @@
 </p>
 <div align="center">
 
-  [![npm version](https://badge.fury.io/js/@fireblocks%2Ffireblocks-web3-provider.svg)](https://badge.fury.io/js/@fireblocks%2Ffireblocks-web3-provider) </br>
-  [<ins>Fireblocks Web3 Provider Documentation</ins>](https://developers.fireblocks.com/docs/ethereum-development)
-</div>
+[![npm version](https://badge.fury.io/js/@fireblocks%2Ffireblocks-web3-provider.svg)](https://badge.fury.io/js/@fireblocks%2Ffireblocks-web3-provider) </br>
+[<ins>Fireblocks Web3 Provider Documentation</ins>](https://developers.fireblocks.com/docs/ethereum-development)
 
+</div>
 
 # Fireblocks Web3 Provider
 
 Fireblocks [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) Compatible Ethereum JavaScript Provider
 
 ## Installation
+
 ```bash
 npm install @fireblocks/fireblocks-web3-provider
 ```
 
 ## Setup
+
 ```js
-import { FireblocksWeb3Provider, ChainId, ApiBaseUrl } from "@fireblocks/fireblocks-web3-provider";
+import {
+  FireblocksWeb3Provider,
+  ChainId,
+  ApiBaseUrl,
+} from "@fireblocks/fireblocks-web3-provider";
 
 const eip1193Provider = new FireblocksWeb3Provider({
-    // apiBaseUrl: ApiBaseUrl.Sandbox // If using a sandbox workspace
-    privateKey: process.env.FIREBLOCKS_API_PRIVATE_KEY_PATH,
-    apiKey: process.env.FIREBLOCKS_API_KEY,
-    vaultAccountIds: process.env.FIREBLOCKS_VAULT_ACCOUNT_IDS,
-    chainId: ChainId.GOERLI,
+  // apiBaseUrl: ApiBaseUrl.Sandbox // If using a sandbox workspace
+  privateKey: process.env.FIREBLOCKS_API_PRIVATE_KEY_PATH,
+  apiKey: process.env.FIREBLOCKS_API_KEY,
+  vaultAccountIds: process.env.FIREBLOCKS_VAULT_ACCOUNT_IDS,
+  chainId: ChainId.HOLESKY,
 
-    logTransactionStatusChanges: true, // Verbose logging
-})
+  logTransactionStatusChanges: true, // Verbose logging
+});
 ```
 
 ## Usage with ethers.js
+
 ```sh
 npm install ethers@5
 ```
 
 ```js
-import * as ethers from "ethers"
+import * as ethers from "ethers";
 
 const provider = new ethers.providers.Web3Provider(eip1193Provider);
 // const provider = new ethers.BrowserProvider(eip1193Provider); // For ethers v6
 ```
 
 ## Usage with web3.js
+
 ```sh
 npm install web3
 ```
@@ -68,96 +76,96 @@ This class is an [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) Compatible 
 ```ts
 type FireblocksProviderConfig = {
   // ------------- Mandatory fields -------------
-  /** 
-   * Learn more about creating API users here: 
+  /**
+   * Learn more about creating API users here:
    * https://developers.fireblocks.com/docs/quickstart#api-user-creation
    */
 
-  /** 
+  /**
    * Fireblocks API key
    */
-  apiKey: string,
+  apiKey: string;
 
-  /** 
+  /**
    * Fireblocks API private key for signing requests
    */
-  privateKey: string,
+  privateKey: string;
 
   // Either chainId or rpcUrl must be provided
-  /** 
-   * If not provided, it is inferred from the rpcUrl 
+  /**
+   * If not provided, it is inferred from the rpcUrl
    */
-  chainId?: ChainId,
-  /** 
-   * If not provided, it is inferred from the chainId 
+  chainId?: ChainId;
+  /**
+   * If not provided, it is inferred from the chainId
    */
-  rpcUrl?: string,
+  rpcUrl?: string;
 
   // ------------- Optional fields --------------
 
-  /** 
+  /**
    * By default, the first 20 vault accounts are dynamically loaded from the Fireblocks API
    * It is recommended to provide the vault account ids explicitly because it helps avoid unnecessary API calls
    */
-  vaultAccountIds?: number | number[] | string | string[],
-  /** 
+  vaultAccountIds?: number | number[] | string | string[];
+  /**
    * By default, it uses the Fireblocks API production endpoint
    * When using a sandbox workspace, you should provide the ApiBaseUrl.Sandbox value
    */
-  apiBaseUrl?: ApiBaseUrl | string,
+  apiBaseUrl?: ApiBaseUrl | string;
   /**
    * By default, the fallback fee level is set to FeeLevel.MEDIUM
    */
-  fallbackFeeLevel?: FeeLevel,
+  fallbackFeeLevel?: FeeLevel;
   /**
    * By default, the note is set to "Created by Fireblocks Web3 Provider"
    */
-  note?: string,
+  note?: string;
   /**
    * By default, the polling interval is set to 1000ms (1 second)
    * It is the interval in which the Fireblocks API is queried to check the status of transactions
    */
-  pollingInterval?: number,
+  pollingInterval?: number;
   /**
    * By default, it is assumed that one time addresses are enabled in your workspace
    * If they're not, set this to false
    */
-  oneTimeAddressesEnabled?: boolean,
+  oneTimeAddressesEnabled?: boolean;
   /**
    * By default, no externalTxId is associated with transactions
    * If you want to set one, you can either provide a function that returns a string, or provide a string directly
    */
-  externalTxId?: (() => string) | string,
+  externalTxId?: (() => string) | string;
   /**
    * If you want to prepend an additional product string to the User-Agent header, you can provide it here
    */
-  userAgent?: string,
+  userAgent?: string;
   /**
    * If you are using a private/custom EVM chain, you can provide its Fireblocks assetId here
    */
-  assetId?: string,
+  assetId?: string;
   /**
    * Default: false
    * By setting to true, every transaction status change will be logged to the console
    * Same as setting env var `DEBUG=fireblocks-web3-provider:status`
    */
-  logTransactionStatusChanges?: boolean,
+  logTransactionStatusChanges?: boolean;
   /**
    * Default: false
    * By setting to true, every request and response processed by the provider will be logged to the console
    * Same as setting env var `DEBUG=fireblocks-web3-provider:req_res`
    */
-  logRequestsAndResponses?: boolean,
+  logRequestsAndResponses?: boolean;
   /**
    * Default: true
    * By setting to true, every failed transaction will print additional information
    * helpful for debugging, such as a link to simulate the transaction on Tenderly
    * Same as setting env var `DEBUG=fireblocks-web3-provider:error`
    */
-  enhancedErrorHandling?: boolean,
+  enhancedErrorHandling?: boolean;
   /**
    * Proxy path in the format of `http(s)://user:pass@server`
    */
-  proxyPath?: string
-}
+  proxyPath?: string;
+};
 ```

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,61 +2,180 @@ import { TransactionStatus } from "fireblocks-sdk";
 import { ChainId, Asset } from "./types";
 
 export const ASSETS: { [key: string]: Asset } = {
-  [ChainId.MAINNET]: { assetId: 'ETH', rpcUrl: "https://cloudflare-eth.com" },
-  [ChainId.ROPSTEN]: { assetId: 'ETH_TEST', rpcUrl: "https://rpc.ankr.com/eth_ropsten" },
-  [ChainId.KOVAN]: { assetId: 'ETH_TEST2', rpcUrl: "https://kovan.poa.network" },
-  [ChainId.GOERLI]: { assetId: 'ETH_TEST3', rpcUrl: "https://rpc.ankr.com/eth_goerli" },
-  [ChainId.RINKEBY]: { assetId: 'ETH_TEST4', rpcUrl: "https://rpc.ankr.com/eth_rinkeby" },
-  [ChainId.SEPOLIA]: { assetId: 'ETH_TEST5', rpcUrl: "https://rpc.sepolia.org" },
-  [ChainId.HOLESKY]: { assetId: 'ETH_TEST6', rpcUrl: "https://ethereum-holesky.publicnode.com" },
-  [ChainId.BSC]: { assetId: 'BNB_BSC', rpcUrl: "https://bsc-dataseed.binance.org" },
-  [ChainId.BSC_TEST]: { assetId: 'BNB_TEST', rpcUrl: "https://data-seed-prebsc-1-s1.binance.org:8545" },
-  [ChainId.POLYGON]: { assetId: 'MATIC_POLYGON', rpcUrl: "https://polygon-rpc.com" },
-  [ChainId.POLYGON_TEST]: { assetId: 'MATIC_POLYGON_MUMBAI', rpcUrl: "https://rpc-mumbai.maticvigil.com" },
-  [ChainId.POLYGON_AMOY]: { assetId: 'AMOY_POLYGON_TEST', rpcUrl: "https://rpc-amoy.polygon.technology" },
-  [ChainId.AVALANCHE]: { assetId: 'AVAX', rpcUrl: "https://api.avax.network/ext/bc/C/rpc" },
-  [ChainId.AVALANCHE_TEST]: { assetId: 'AVAXTEST', rpcUrl: "https://api.avax-test.network/ext/bc/C/rpc" },
-  [ChainId.MOONRIVER]: { assetId: 'MOVR_MOVR', rpcUrl: "https://rpc.moonriver.moonbeam.network" },
-  [ChainId.MOONBEAM]: { assetId: 'GLMR_GLMR', rpcUrl: "https://rpc.api.moonbeam.network" },
-  [ChainId.SONGBIRD]: { assetId: 'SGB', rpcUrl: "https://songbird.towolabs.com/rpc" },
-  [ChainId.ARBITRUM]: { assetId: 'ETH-AETH', rpcUrl: "https://rpc.ankr.com/arbitrum" },
-  [ChainId.ARBITRUM_SEPOLIA]: { assetId: 'ETH-AETH_SEPOLIA', rpcUrl: "https://sepolia-rollup.arbitrum.io/rpc" },
-  [ChainId.ARBITRUM_RIN]: { assetId: 'ETH-AETH-RIN', rpcUrl: "https://rinkeby.arbitrum.io/rpc" },
-  [ChainId.FANTOM]: { assetId: 'FTM_FANTOM', rpcUrl: "https://rpc.ftm.tools/" },
-  [ChainId.RSK]: { assetId: 'RBTC', rpcUrl: "https://public-node.rsk.co" },
-  [ChainId.RSK_TEST]: { assetId: 'RBTC_TEST', rpcUrl: "https://public-node.testnet.rsk.co" },
-  [ChainId.CELO]: { assetId: 'CELO', rpcUrl: "https://rpc.ankr.com/celo" },
-  [ChainId.CELO_BAK]: { assetId: 'CELO_BAK', rpcUrl: "https://baklava-blockscout.celo-testnet.org/api/eth-rpc" },
-  [ChainId.CELO_ALF]: { assetId: 'CELO_ALF', rpcUrl: "https://alfajores-forno.celo-testnet.org/api/eth-rpc" },
-  [ChainId.OPTIMISM]: { assetId: 'ETH-OPT', rpcUrl: "https://rpc.ankr.com/optimism" },
-  [ChainId.OPTIMISM_KOVAN]: { assetId: 'ETH-OPT_KOV', rpcUrl: "https://kovan.optimism.io/" },
-  [ChainId.OPTIMISM_SEPOLIA]: { assetId: 'ETH-OPT_SEPOLIA', rpcUrl: "https://sepolia.optimism.io/" },
-  [ChainId.RONIN]: { assetId: 'RON', rpcUrl: "https://api.roninchain.com/rpc" },
-  [ChainId.CANTO]: { assetId: 'CANTO', rpcUrl: "https://canto.gravitychain.io" },
-  [ChainId.CANTO_TEST]: { assetId: 'CANTO_TEST', rpcUrl: "https://testnet-archive.plexnode.wtf" },
-  [ChainId.POLYGON_ZKEVM]: { assetId: 'ETH_ZKEVM', rpcUrl: "https://zkevm-rpc.com" },
-  [ChainId.POLYGON_ZKEVM_TEST]: { assetId: 'ETH_ZKEVM_TEST', rpcUrl: "https://rpc.public.zkevm-test.net" },
-  [ChainId.KAVA]: { assetId: 'KAVA_KAVA', rpcUrl: "https://evm.kava.io" },
-  [ChainId.SMARTBCH]: { assetId: 'SMARTBCH', rpcUrl: "https://smartbch.greyh.at" },
-  [ChainId.SMARTBCH_TEST]: { assetId: 'ETHW', rpcUrl: "https://rpc-testnet.smartbch.org" },
-  [ChainId.HECO]: { assetId: 'HT_CHAIN', rpcUrl: "https://http-mainnet.hecochain.com" },
-  [ChainId.AURORA]: { assetId: 'AURORA_DEV', rpcUrl: "https://mainnet.aurora.dev" },
-  [ChainId.RISEOFTHEWARBOTSTESTNET]: { assetId: 'TKX', rpcUrl: "https://testnet1.rotw.games" },
-  [ChainId.EVMOS]: { assetId: 'EVMOS', rpcUrl: "https://eth.bd.evmos.org" },
-  [ChainId.ASTAR]: { assetId: 'ASTR_ASTR', rpcUrl: "https://evm.astar.network" },
-  [ChainId.VELAS]: { assetId: 'VLX_VLX', rpcUrl: "https://evmexplorer.velas.com/rpc" },
-  [ChainId.ARB_GOERLI]: { assetId: 'ETH-AETH_GOERLI', rpcUrl: "https://endpoints.omniatech.io/v1/arbitrum/goerli/public" },
-  [ChainId.XDC]: { assetId: 'XDC', rpcUrl: "https://rpc.xdcrpc.com" },
-  [ChainId.BASE]: { assetId: 'BASECHAIN_ETH', rpcUrl: "https://mainnet.base.org" },
-  [ChainId.BASE_SEPOLIA]: { assetId: 'BASECHAIN_ETH_TEST5', rpcUrl: "https://sepolia.base.org" },
-  [ChainId.IVAR]: { assetId: 'CHZ_CHZ2', rpcUrl: "https://mainnet-rpc.ivarex.com" },
-  [ChainId.JOC]: { assetId: 'ASTR_TEST', rpcUrl: "https://rpc-1.japanopenchain.org:8545" },
-  [ChainId.OASYS]: { assetId: 'OAS', rpcUrl: "https://oasys.blockpi.network/v1/rpc/public" },
-  [ChainId.SHIMMEREVM]: { assetId: 'SMR_SMR', rpcUrl: "https://json-rpc.evm.shimmer.network" },
-  [ChainId.LINEA]: { assetId: 'LINEA', rpcUrl: "https://rpc.linea.build" },
-  [ChainId.LINEA_TEST]: { assetId: 'LINEA_TEST', rpcUrl: "https://rpc.goerli.linea.build" },
-  [ChainId.FLARE]: { assetId: 'FLR', rpcUrl: "https://flare-api.flare.network/ext/C/rpc" },
-}
+  [ChainId.MAINNET]: { assetId: "ETH", rpcUrl: "https://cloudflare-eth.com" },
+  [ChainId.SEPOLIA]: {
+    assetId: "ETH_TEST5",
+    rpcUrl: "https://rpc.sepolia.org",
+  },
+  [ChainId.HOLESKY]: {
+    assetId: "ETH_TEST6",
+    rpcUrl: "https://ethereum-holesky.publicnode.com",
+  },
+  [ChainId.BSC]: {
+    assetId: "BNB_BSC",
+    rpcUrl: "https://bsc-dataseed.binance.org",
+  },
+  [ChainId.BSC_TEST]: {
+    assetId: "BNB_TEST",
+    rpcUrl: "https://data-seed-prebsc-1-s1.binance.org:8545",
+  },
+  [ChainId.POLYGON]: {
+    assetId: "MATIC_POLYGON",
+    rpcUrl: "https://polygon-rpc.com",
+  },
+  [ChainId.POLYGON_TEST]: {
+    assetId: "MATIC_POLYGON_MUMBAI",
+    rpcUrl: "https://rpc-mumbai.maticvigil.com",
+  },
+  [ChainId.POLYGON_AMOY]: {
+    assetId: "AMOY_POLYGON_TEST",
+    rpcUrl: "https://rpc-amoy.polygon.technology",
+  },
+  [ChainId.AVALANCHE]: {
+    assetId: "AVAX",
+    rpcUrl: "https://api.avax.network/ext/bc/C/rpc",
+  },
+  [ChainId.AVALANCHE_TEST]: {
+    assetId: "AVAXTEST",
+    rpcUrl: "https://api.avax-test.network/ext/bc/C/rpc",
+  },
+  [ChainId.MOONRIVER]: {
+    assetId: "MOVR_MOVR",
+    rpcUrl: "https://rpc.moonriver.moonbeam.network",
+  },
+  [ChainId.MOONBEAM]: {
+    assetId: "GLMR_GLMR",
+    rpcUrl: "https://rpc.api.moonbeam.network",
+  },
+  [ChainId.SONGBIRD]: {
+    assetId: "SGB",
+    rpcUrl: "https://songbird.towolabs.com/rpc",
+  },
+  [ChainId.ARBITRUM]: {
+    assetId: "ETH-AETH",
+    rpcUrl: "https://rpc.ankr.com/arbitrum",
+  },
+  [ChainId.ARBITRUM_SEPOLIA]: {
+    assetId: "ETH-AETH_SEPOLIA",
+    rpcUrl: "https://sepolia-rollup.arbitrum.io/rpc",
+  },
+  [ChainId.ARBITRUM_RIN]: {
+    assetId: "ETH-AETH-RIN",
+    rpcUrl: "https://rinkeby.arbitrum.io/rpc",
+  },
+  [ChainId.FANTOM]: { assetId: "FTM_FANTOM", rpcUrl: "https://rpc.ftm.tools/" },
+  [ChainId.RSK]: { assetId: "RBTC", rpcUrl: "https://public-node.rsk.co" },
+  [ChainId.RSK_TEST]: {
+    assetId: "RBTC_TEST",
+    rpcUrl: "https://public-node.testnet.rsk.co",
+  },
+  [ChainId.CELO]: { assetId: "CELO", rpcUrl: "https://rpc.ankr.com/celo" },
+  [ChainId.CELO_BAK]: {
+    assetId: "CELO_BAK",
+    rpcUrl: "https://baklava-blockscout.celo-testnet.org/api/eth-rpc",
+  },
+  [ChainId.CELO_ALF]: {
+    assetId: "CELO_ALF",
+    rpcUrl: "https://alfajores-forno.celo-testnet.org/api/eth-rpc",
+  },
+  [ChainId.OPTIMISM]: {
+    assetId: "ETH-OPT",
+    rpcUrl: "https://rpc.ankr.com/optimism",
+  },
+  [ChainId.OPTIMISM_KOVAN]: {
+    assetId: "ETH-OPT_KOV",
+    rpcUrl: "https://kovan.optimism.io/",
+  },
+  [ChainId.OPTIMISM_SEPOLIA]: {
+    assetId: "ETH-OPT_SEPOLIA",
+    rpcUrl: "https://sepolia.optimism.io/",
+  },
+  [ChainId.RONIN]: { assetId: "RON", rpcUrl: "https://api.roninchain.com/rpc" },
+  [ChainId.CANTO]: {
+    assetId: "CANTO",
+    rpcUrl: "https://canto.gravitychain.io",
+  },
+  [ChainId.CANTO_TEST]: {
+    assetId: "CANTO_TEST",
+    rpcUrl: "https://testnet-archive.plexnode.wtf",
+  },
+  [ChainId.POLYGON_ZKEVM]: {
+    assetId: "ETH_ZKEVM",
+    rpcUrl: "https://zkevm-rpc.com",
+  },
+  [ChainId.POLYGON_ZKEVM_TEST]: {
+    assetId: "ETH_ZKEVM_TEST",
+    rpcUrl: "https://rpc.public.zkevm-test.net",
+  },
+  [ChainId.KAVA]: { assetId: "KAVA_KAVA", rpcUrl: "https://evm.kava.io" },
+  [ChainId.SMARTBCH]: {
+    assetId: "SMARTBCH",
+    rpcUrl: "https://smartbch.greyh.at",
+  },
+  [ChainId.SMARTBCH_TEST]: {
+    assetId: "ETHW",
+    rpcUrl: "https://rpc-testnet.smartbch.org",
+  },
+  [ChainId.HECO]: {
+    assetId: "HT_CHAIN",
+    rpcUrl: "https://http-mainnet.hecochain.com",
+  },
+  [ChainId.AURORA]: {
+    assetId: "AURORA_DEV",
+    rpcUrl: "https://mainnet.aurora.dev",
+  },
+  [ChainId.RISEOFTHEWARBOTSTESTNET]: {
+    assetId: "TKX",
+    rpcUrl: "https://testnet1.rotw.games",
+  },
+  [ChainId.EVMOS]: { assetId: "EVMOS", rpcUrl: "https://eth.bd.evmos.org" },
+  [ChainId.ASTAR]: {
+    assetId: "ASTR_ASTR",
+    rpcUrl: "https://evm.astar.network",
+  },
+  [ChainId.VELAS]: {
+    assetId: "VLX_VLX",
+    rpcUrl: "https://evmexplorer.velas.com/rpc",
+  },
+  [ChainId.ARB_GOERLI]: {
+    assetId: "ETH-AETH_GOERLI",
+    rpcUrl: "https://endpoints.omniatech.io/v1/arbitrum/goerli/public",
+  },
+  [ChainId.XDC]: { assetId: "XDC", rpcUrl: "https://rpc.xdcrpc.com" },
+  [ChainId.BASE]: {
+    assetId: "BASECHAIN_ETH",
+    rpcUrl: "https://mainnet.base.org",
+  },
+  [ChainId.BASE_SEPOLIA]: {
+    assetId: "BASECHAIN_ETH_TEST5",
+    rpcUrl: "https://sepolia.base.org",
+  },
+  [ChainId.IVAR]: {
+    assetId: "CHZ_CHZ2",
+    rpcUrl: "https://mainnet-rpc.ivarex.com",
+  },
+  [ChainId.JOC]: {
+    assetId: "ASTR_TEST",
+    rpcUrl: "https://rpc-1.japanopenchain.org:8545",
+  },
+  [ChainId.OASYS]: {
+    assetId: "OAS",
+    rpcUrl: "https://oasys.blockpi.network/v1/rpc/public",
+  },
+  [ChainId.SHIMMEREVM]: {
+    assetId: "SMR_SMR",
+    rpcUrl: "https://json-rpc.evm.shimmer.network",
+  },
+  [ChainId.LINEA]: { assetId: "LINEA", rpcUrl: "https://rpc.linea.build" },
+  [ChainId.LINEA_TEST]: {
+    assetId: "LINEA_TEST",
+    rpcUrl: "https://rpc.goerli.linea.build",
+  },
+  [ChainId.FLARE]: {
+    assetId: "FLR",
+    rpcUrl: "https://flare-api.flare.network/ext/C/rpc",
+  },
+};
 
 export const SIGNER_METHODS = [
   "eth_sendTransaction",
@@ -69,7 +188,7 @@ export const SIGNER_METHODS = [
   "eth_accounts",
   "eth_sign",
   "eth_signTransaction",
-]
+];
 
 export const FINAL_TRANSACTION_STATES = [
   TransactionStatus.COMPLETED,
@@ -79,15 +198,15 @@ export const FINAL_TRANSACTION_STATES = [
   TransactionStatus.REJECTED,
   TransactionStatus.BROADCASTING,
   TransactionStatus.CONFIRMING,
-]
+];
 
 export const FINAL_SUCCESSFUL_TRANSACTION_STATES = [
   TransactionStatus.COMPLETED,
   TransactionStatus.BROADCASTING,
   TransactionStatus.CONFIRMING,
-]
+];
 
-export const DEBUG_NAMESPACE = 'fireblocks-web3-provider'
-export const DEBUG_NAMESPACE_TX_STATUS_CHANGES = `${DEBUG_NAMESPACE}:status`
-export const DEBUG_NAMESPACE_ENHANCED_ERROR_HANDLING = `${DEBUG_NAMESPACE}:error`
-export const DEBUG_NAMESPACE_REQUESTS_AND_RESPONSES = `${DEBUG_NAMESPACE}:req_res`
+export const DEBUG_NAMESPACE = "fireblocks-web3-provider";
+export const DEBUG_NAMESPACE_TX_STATUS_CHANGES = `${DEBUG_NAMESPACE}:status`;
+export const DEBUG_NAMESPACE_ENHANCED_ERROR_HANDLING = `${DEBUG_NAMESPACE}:error`;
+export const DEBUG_NAMESPACE_REQUESTS_AND_RESPONSES = `${DEBUG_NAMESPACE}:req_res`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,10 +3,6 @@ import { AxiosProxyConfig } from "axios";
 
 export enum ChainId {
   MAINNET = 1,
-  ROPSTEN = 3,
-  KOVAN = 42,
-  GOERLI = 5,
-  RINKEBY = 4,
   SEPOLIA = 11155111,
   HOLESKY = 17000,
   BSC = 56,
@@ -64,9 +60,9 @@ export enum ApiBaseUrl {
 }
 
 export type Asset = {
-  assetId: string,
-  rpcUrl: string,
-}
+  assetId: string;
+  rpcUrl: string;
+};
 
 export enum RawMessageType {
   EIP712 = "EIP712",
@@ -75,108 +71,108 @@ export enum RawMessageType {
 
 export type FireblocksProviderConfig = {
   // ------------- Mandatory fields -------------
-  /** 
-   * Learn more about creating API users here: 
+  /**
+   * Learn more about creating API users here:
    * https://developers.fireblocks.com/docs/quickstart#api-user-creation
    */
 
-  /** 
+  /**
    * Fireblocks API key
    */
-  apiKey: string,
+  apiKey: string;
 
-  /** 
+  /**
    * Fireblocks API private key for signing requests
    */
-  privateKey: string,
+  privateKey: string;
 
   // Either chainId or rpcUrl must be provided
-  /** 
-   * If not provided, it is inferred from the rpcUrl 
+  /**
+   * If not provided, it is inferred from the rpcUrl
    */
-  chainId?: ChainId,
-  /** 
-   * If not provided, it is inferred from the chainId 
+  chainId?: ChainId;
+  /**
+   * If not provided, it is inferred from the chainId
    */
-  rpcUrl?: string,
+  rpcUrl?: string;
 
   // ------------- Optional fields --------------
 
-  /** 
+  /**
    * By default, the first 20 vault accounts are dynamically loaded from the Fireblocks API
    * It is recommended to provide the vault account ids explicitly because it helps avoid unnecessary API calls
    */
-  vaultAccountIds?: number | number[] | string | string[],
-  /** 
+  vaultAccountIds?: number | number[] | string | string[];
+  /**
    * By default, it uses the Fireblocks API production endpoint
    * When using a sandbox workspace, you should provide the ApiBaseUrl.Sandbox value
    */
-  apiBaseUrl?: ApiBaseUrl | string,
+  apiBaseUrl?: ApiBaseUrl | string;
   /**
    * By default, the fallback fee level is set to FeeLevel.MEDIUM
    */
-  fallbackFeeLevel?: FeeLevel,
+  fallbackFeeLevel?: FeeLevel;
   /**
    * By default, the note is set to "Created by Fireblocks Web3 Provider"
    */
-  note?: string,
+  note?: string;
   /**
    * By default, the polling interval is set to 1000ms (1 second)
    * It is the interval in which the Fireblocks API is queried to check the status of transactions
    */
-  pollingInterval?: number,
+  pollingInterval?: number;
   /**
    * By default, it is assumed that one time addresses are enabled in your workspace
    * If they're not, set this to false
    */
-  oneTimeAddressesEnabled?: boolean,
+  oneTimeAddressesEnabled?: boolean;
   /**
    * By default, no externalTxId is associated with transactions
    * If you want to set one, you can either provide a function that returns a string, or provide a string directly
    */
-  externalTxId?: (() => string) | string,
+  externalTxId?: (() => string) | string;
   /**
    * If you want to prepend an additional product string to the User-Agent header, you can provide it here
    */
-  userAgent?: string,
+  userAgent?: string;
   /**
    * If you are using a private/custom EVM chain, you can provide its Fireblocks assetId here
    */
-  assetId?: string,
+  assetId?: string;
   /**
    * Default: false
    * By setting to true, every transaction status change will be logged to the console
    * Same as setting env var `DEBUG=fireblocks-web3-provider:status`
    */
-  logTransactionStatusChanges?: boolean,
+  logTransactionStatusChanges?: boolean;
   /**
    * Default: false
    * By setting to true, every request and response processed by the provider will be logged to the console
    * Same as setting env var `DEBUG=fireblocks-web3-provider:req_res`
    */
-  logRequestsAndResponses?: boolean,
+  logRequestsAndResponses?: boolean;
   /**
    * Default: true
    * By setting to true, every failed transaction will print additional information
    * helpful for debugging, such as a link to simulate the transaction on Tenderly
    * Same as setting env var `DEBUG=fireblocks-web3-provider:error`
    */
-  enhancedErrorHandling?: boolean,
+  enhancedErrorHandling?: boolean;
   /**
    * Warning: This is an undocumented experimental flag that is subject to breaking changes
    * Warning: Use at your own risk
    * By default, no contracts are interacted with gaslessly
-   * By setting a gaslessGasTankVaultId, all transactions will be sent gaslessly, 
+   * By setting a gaslessGasTankVaultId, all transactions will be sent gaslessly,
    * relayed via the provided vault account
    */
-  gaslessGasTankVaultId?: number,
+  gaslessGasTankVaultId?: number;
 
   /**
    * Proxy path in the format of `http(s)://user:pass@server`.
    * Note that all connections performed via the proxy will be done using CONNECT HTTP method.
    */
-  proxyPath?: string,
-}
+  proxyPath?: string;
+};
 
 export interface RequestArguments<T = any> {
   method: string;


### PR DESCRIPTION
Hi Team,

I noticed some unavailable testnets in this repository in types.ts that can no longer be used. I've already started cleaning them up.

I also propose updating the documentation to showcase the new ```HOLESKY``` testnet instead of the deprecated ```GOERLI```. This will help prevent confusion for new users who might encounter errors when trying to use the old testnet.

Please check and review. 