### PR TITLE
add blast mainnet rpc_url and chainId to types and constants

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,6 +58,8 @@ export const ASSETS: { [key: string]: Asset } = {
   [ChainId.FLARE]: { assetId: 'FLR', rpcUrl: "https://flare-api.flare.network/ext/C/rpc" },
   [ChainId.MANTLE]: { assetId: 'MANTLE', rpcUrl: "https://rpc.mantle.xyz" },
   [ChainId.MANTLE_TEST]: { assetId: 'MANTLE_TEST', rpcUrl: "https://rpc.testnet.mantle.xyz" },
+  [ChainId.BLAST]: { assetId: 'BLAST', rpcUrl: "https://rpc.ankr.com/blast"},
+  // [ChainId.BLAST_SEPOLIA]: { assetId: 'BLAST_TEST', rpcUrl: "https://sepolia.blast.io"},
 }
 
 export const SIGNER_METHODS = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,8 @@ export enum ChainId {
   FLARE = 14,
   MANTLE = 5000,
   MANTLE_TEST = 5001,
+  BLAST = 81457,
+  // BLAST_SEPOLIA = 168587773, 
 }
 
 export enum ApiBaseUrl {


### PR DESCRIPTION
Added Blast mainnet to list of chains via Blast's network docs https://docs.blast.io/building/network-information
chainId: 81457,  via RPC URL: https://rpc.blast.io

I see we do not have BLAST Sepolia support yet on the console and will hold off on adding BLAST Sepolia chainId and rpc url until Blast SEPOLIA asset is supported. 

@orenyomtov 
