### PR TITLE
Update Sepolia RPC URL

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,7 @@ export const ASSETS: { [key: string]: Asset } = {
   [ChainId.KOVAN]: { assetId: 'ETH_TEST2', rpcUrl: "https://kovan.poa.network" },
   [ChainId.GOERLI]: { assetId: 'ETH_TEST3', rpcUrl: "https://rpc.ankr.com/eth_goerli" },
   [ChainId.RINKEBY]: { assetId: 'ETH_TEST4', rpcUrl: "https://rpc.ankr.com/eth_rinkeby" },
-  [ChainId.SEPOLIA]: { assetId: 'ETH_TEST5', rpcUrl: "https://rpc.sepolia.org" },
+  [ChainId.SEPOLIA]: { assetId: 'ETH_TEST5', rpcUrl: "https://ethereum-sepolia-rpc.publicnode.com" },
   [ChainId.HOLESKY]: { assetId: 'ETH_TEST6', rpcUrl: "https://ethereum-holesky-rpc.publicnode.com" },
   [ChainId.BSC]: { assetId: 'BNB_BSC', rpcUrl: "https://bsc-dataseed.binance.org" },
   [ChainId.BSC_TEST]: { assetId: 'BNB_TEST', rpcUrl: "https://data-seed-prebsc-1-s1.binance.org:8545" },


### PR DESCRIPTION
I recommend updating rpcUrl for Sepolia to another URL like https://ethereum-sepolia-rpc.publicnode.com because https://rpc.sepolia.org is not working.

- Status of `rpc.sepolia.org`
  - https://status.sepolia.org/
  - https://chainlist.org/chain/11155111