### PR TITLE
chore: remove NODE_AUTH_TOKEN from npm publish step in workflow - Using Trusted Publisher instead

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,5 +32,3 @@ jobs:
           git commit -m "release $tag"
           git push
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "ts-node": {
+    "transpileOnly": true
+  },
   "compilerOptions": {
     "target": "ES2017",
     "module": "commonjs",


### PR DESCRIPTION
- Cleaned up the publish-npm.yml workflow by removing the NODE_AUTH_TOKEN environment variable, as it is no longer needed.