### PR TITLE
ci: simplify publish workflow (remove blocked auto-bump)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [published]
 env:
-  GIT_TERMINAL_PROMPT: 1    
+  GIT_TERMINAL_PROMPT: 1
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -16,21 +16,6 @@ jobs:
           node-version: '16.14.2'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
-      - run: |
-          initialTag=${{ github.event.release.tag_name }}
-          tag="${initialTag//[v]/}"
-          echo $tag
-          git remote update
-          git fetch
-          git checkout --track origin/main
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "Github Actions"
-          npm --no-git-tag-version --allow-same-version version $tag
-          npm i -g auto-changelog
-          auto-changelog --hide-credit -l 100
-          git add .
-          git commit -m "release $tag"
-          git push
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Problem:** publish-npm.yml auto-bump step pushes to main, blocked by org ruleset (GH013). Has been broken for every release attempt since 2026-02-25. Currently blocking v1.4.0 (security fix GHSA-x3ff-w252-2g7j for x15ventures/COR-203576).

**Fix:** drop the auto-bump entirely. Version + CHANGELOG already maintained in release PRs (v1.4.0 PR #70 already did this). Workflow now only publishes.

**Future release flow:** bump version + update CHANGELOG in release PR → merge → create release → workflow publishes.