### PR TITLE
ci: switch publish to npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -7,15 +7,18 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: '16.14.2'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install
+      - name: Ensure npm 11.5.1+ (required for OIDC trusted publishing)
+        run: npm install -g npm@^11
+      - run: npm ci
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Trusted Publisher already configured on npm side. Mirrors fireblocks-json-rpc and ts-sdk.