### PR TITLE
feat: add Robinhood Chain support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -78,6 +78,7 @@ export const ASSETS: { [key: string]: Asset } = {
   [ChainId.PLUME]: {assetId: 'PLUME_PLUME', rpcUrl: "https://plume.drpc.org" },
   [ChainId.SOPHON]: {assetId: 'SOPHON', rpcUrl: "https://rpc.sophon.xyz" },
   [ChainId.ARC_TEST]: {assetId: 'ARC_TEST', rpcUrl: "https://rpc.testnet.arc.network" },
+  [ChainId.ROBINHOOD]: {assetId: 'ROBINHOOD', rpcUrl: "https://rpc.mainnet.chain.robinhood.com" },
 }
 
 export const SIGNER_METHODS = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,7 @@ export enum ChainId {
   PLUME = 98866,
   SOPHON = 50104,
   ARC_TEST = 5042002,
+  ROBINHOOD = 4663,
 }
 
 export enum ApiBaseUrl {


### PR DESCRIPTION
Add Robinhood Chain (mainnet, chain id 4663) to the ChainId enum and ASSETS map, following the existing EVM chain pattern.