### PR TITLE
feat: add ADI Chain mainnet and testnet support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,6 +79,8 @@ export const ASSETS: { [key: string]: Asset } = {
   [ChainId.SOPHON]: {assetId: 'SOPHON', rpcUrl: "https://rpc.sophon.xyz" },
   [ChainId.ARC_TEST]: {assetId: 'ARC_TEST', rpcUrl: "https://rpc.testnet.arc.network" },
   [ChainId.ROBINHOOD]: {assetId: 'ROBINHOOD', rpcUrl: "https://rpc.mainnet.chain.robinhood.com" },
+  [ChainId.ADI_CHAIN]: {assetId: 'ADI_CHAIN', rpcUrl: "https://rpc.adifoundation.ai" },
+  [ChainId.ADI_CHAIN_TEST]: {assetId: 'ADI_CHAIN_TEST', rpcUrl: "https://rpc.ab.testnet.adifoundation.ai" },
 }
 
 export const SIGNER_METHODS = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,8 @@ export enum ChainId {
   SOPHON = 50104,
   ARC_TEST = 5042002,
   ROBINHOOD = 4663,
+  ADI_CHAIN = 36900,
+  ADI_CHAIN_TEST = 99999,
 }
 
 export enum ApiBaseUrl {

--- a/test/unit/chainAssets.test.ts
+++ b/test/unit/chainAssets.test.ts
@@ -1,0 +1,21 @@
+import { expect } from "chai";
+import { ChainId } from "../../src/types";
+import { getAssetByChain } from "../../src/utils";
+
+describe("ASSETS — ADI Chain mapping", function () {
+  it("maps ADI Chain mainnet (chain id 36900) to ADI_CHAIN", function () {
+    expect(ChainId.ADI_CHAIN).to.equal(36900);
+    expect(getAssetByChain(36900)).to.deep.equal({
+      assetId: "ADI_CHAIN",
+      rpcUrl: "https://rpc.adifoundation.ai",
+    });
+  });
+
+  it("maps ADI Network AB Testnet (chain id 99999) to ADI_CHAIN_TEST", function () {
+    expect(ChainId.ADI_CHAIN_TEST).to.equal(99999);
+    expect(getAssetByChain(99999)).to.deep.equal({
+      assetId: "ADI_CHAIN_TEST",
+      rpcUrl: "https://rpc.ab.testnet.adifoundation.ai",
+    });
+  });
+});


### PR DESCRIPTION
Add ADI Chain mainnet (chain id 36900) and ADI Network AB Testnet (chain id 99999) to the `ChainId` enum and `ASSETS` map, following the existing EVM chain pattern.

## Why

Constructing the provider with `chainId: 36900` or `chainId: 99999` throws `Unsupported chain id: …`. Fireblocks already supports both networks (assets `ADI_CHAIN` and `ADI_CHAIN_TEST`); only the chain-id → asset mapping is missing, so `chainId`-based configuration fails before a request reaches Fireblocks — typed-data signing (`eth_signTypedData_v4`) on ADI testnet is the case we hit.

## Chain details

| Network | Chain id | Fireblocks asset id | Default RPC | Explorer | Docs |
|---|---|---|---|---|---|
| ADI Chain (mainnet) | 36900 | `ADI_CHAIN` | https://rpc.adifoundation.ai | https://explorer.adifoundation.ai | https://docs.adi.foundation/how-to-start/adi-network-mainnet-details |
| ADI Network AB Testnet | 99999 | `ADI_CHAIN_TEST` | https://rpc.ab.testnet.adifoundation.ai | https://explorer.ab.testnet.adifoundation.ai | https://docs.adi.foundation/how-to-start/adi-network-testnet-details |

Chain id 99999 is flagged `reusedChainId` in ethereum-lists (previously UB Smart Chain); Fireblocks' `GET /v1/blockchains` reports `onchain.chainId` `99999` for `ADI_CHAIN_TEST`, so the mapping matches the Fireblocks catalog.

## Changes

- `src/types.ts`: `ADI_CHAIN = 36900`, `ADI_CHAIN_TEST = 99999` — member names mirror the Fireblocks asset ids, as with the most recent additions (`ROBINHOOD`, `SOPHON`, `ARC_TEST`)
- `src/constants.ts`: `ASSETS` entries for both chains with the ADI Foundation public RPC endpoints
- `test/unit/chainAssets.test.ts`: pins both mappings (chain id → asset id and default RPC)

## Verification

- `npm run build` and `npx mocha test/unit/*.test.ts` pass locally (60 passing, including the new file)
- Asset ids confirmed against `GET /v1/supported_assets` (`ADI_CHAIN`, `ADI_CHAIN_TEST`; both `BASE_ASSET`, 18 decimals)
- Both RPC endpoints answer `eth_chainId` with `0x9024` (36900) and `0x1869f` (99999)
- Live check against a Fireblocks workspace with this branch: constructing the provider with `chainId: 99999` and calling `eth_signTypedData_v4` created a `TYPED_MESSAGE` transaction carrying `ADI_CHAIN_TEST` and the EIP-712 payload, confirming the mapping resolves end to end

Additive change; no behavior change for existing chains.
